### PR TITLE
Isgl3dPodImporter: Absolute path support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+project.xcworkspace
+xcuserdata
+
+.DS_Store
+*.swp
+*~.nib
+
+build/
+
+*.pbxuser
+*.perspective
+*.perspectivev3

--- a/isgl3d.xcodeproj/project.pbxproj
+++ b/isgl3d.xcodeproj/project.pbxproj
@@ -8743,6 +8743,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				OTHER_CFLAGS = "-mno-thumb";
 				PRODUCT_NAME = isgl3d;
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -8761,6 +8762,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				OTHER_CFLAGS = "-mno-thumb";
 				PRODUCT_NAME = isgl3d;
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};

--- a/isgl3d/importers/Isgl3dPODImporter.h
+++ b/isgl3d/importers/Isgl3dPODImporter.h
@@ -90,15 +90,28 @@ class CPVRTModelPOD;
 
 /**
  * Allocates and initialises (autorelease) importer with the POD data file path.
- * @param path The path to the POD data file.
+ * @param path The main bundle-based path to the POD data file.
  */
 + (id) podImporterWithFile:(NSString *)path;
 
 /**
+ * Allocates and initialises (autorelease) importer with the absolute path to
+ * the POD data.
+ * @param path The absolute path to the POD data file.
+ */
++ (id) podImporterWithAbsoluteFile:(NSString *)path;
+
+/**
  * Initialises the importer with the POD data file path.
- * @param path The path to the POD data file.
+ * @param path The main bundle-based path to the POD data file.
  */
 - (id) initWithFile:(NSString *)path;
+
+/**
+ * Initialises the importer with the absolute path to the POD data file.
+ * @param path The absolute path to the POD data file.
+ */
+- (id) initWithAbsoluteFile:(NSString *)path;
 
 /**
  * Prints to the console information about the structure and contents of the POD.

--- a/isgl3d/importers/Isgl3dPODImporter.mm
+++ b/isgl3d/importers/Isgl3dPODImporter.mm
@@ -69,25 +69,35 @@
 	return [[[self alloc] initWithFile:path] autorelease];
 }
 
++ (id) podImporterWithAbsoluteFile:(NSString *)path {
+	return [[[self alloc] initWithAbsoluteFile:path] autorelease];
+}
+
 - (id) initWithFile:(NSString *)path {
+        // cut filename into name and extension
+        NSString * extension = [path pathExtension];
+        NSString * fileName = [path stringByDeletingPathExtension];
+        NSString * absolutePath = [[NSBundle mainBundle] pathForResource:fileName ofType:extension];
+        if (!absolutePath) {
+                NSLog(@"iSGL3D : Error : Isgl3dPODImporter : POD file %@ does not exist.", path);
+                return nil;
+        } else {
+                return [self initWithAbsoluteFile: absolutePath];
+        }
+}
+
+- (id) initWithAbsoluteFile:(NSString *)absolutePath {
 	if ((self = [super init])) {
 		_podScene = new CPVRTModelPOD();
-
-		// cut filename into name and extension
-		NSString * extension = [path pathExtension];
-		NSString * fileName = [path stringByDeletingPathExtension];
 		
-		if (![[NSBundle mainBundle] pathForResource:fileName ofType:extension]) {
-			NSLog(@"iSGL3D : Error : Isgl3dPODImporter : POD file %@ does not exist.", path);
-		}
-		
-		if (_podScene->ReadFromFile([[[NSBundle mainBundle] pathForResource:fileName ofType:extension] UTF8String]) != PVR_SUCCESS) {
-			NSLog(@"iSGL3D : Error : Isgl3dPODImporter : Unable to parse POD file %@", path);
+		if (_podScene->ReadFromFile([absolutePath UTF8String]) != PVR_SUCCESS) {
+			NSLog(@"iSGL3D : Error : Isgl3dPODImporter : Unable to parse POD file %@", [absolutePath lastPathComponent]);
 			delete _podScene;
 			return nil;
 		}
 		
-		_podPath = path;
+                // Truncate the absolute path to just the filename.
+		_podPath = [absolutePath lastPathComponent];
 
 		_meshes = [[NSMutableArray alloc] init];
 		_meshNodes = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
Closes #10.

API is backwards-compatible. That is, `podImporterWithFile:` and `initWithFile:` both still work.
