### PR TITLE
#35: PODImporter now skips loading material for a mesh if no materials are present.

### DIFF
--- a/isgl3d/importers/Isgl3dPODImporter.mm
+++ b/isgl3d/importers/Isgl3dPODImporter.mm
@@ -617,9 +617,11 @@
 		[_indexedNodes setObject:node forKey:[NSNumber numberWithInteger:meshNodeInfo.nIdx]];
 
 		// Add node alpha
-		SPODMaterial & materialInfo = _podScene->pMaterial[meshNodeInfo.nIdxMaterial];
-		node.alpha = materialInfo.fMatOpacity;
-		node.transparent = node.alpha < 1.0 ? YES : NO;
+        if (meshNodeInfo.nIdxMaterial >= 0 && meshNodeInfo.nIdxMaterial < _podScene->nNumMaterial) {
+            SPODMaterial & materialInfo = _podScene->pMaterial[meshNodeInfo.nIdxMaterial];
+            node.alpha = materialInfo.fMatOpacity;
+            node.transparent = node.alpha < 1.0 ? YES : NO;
+        }
 
 		// Set the default node transformation
 		_podScene->SetFrame(0);


### PR DESCRIPTION
Seems we should allow for the loading of PODs with no materials specified. 
